### PR TITLE
fix: resolve #48 - BUG: Add unit tests for AppDiscovery.build_launch_args and c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,5 @@ config/backups
 # AI
 .understand-anything/intermediate/
 .understand-anything/diff-overlay.json.hermes_tmp_prompt.txt
+# workspace-orchestrator managed entries
+graphify-out/cache/

--- a/tests/test_app_discovery.py
+++ b/tests/test_app_discovery.py
@@ -1,15 +1,10 @@
 """Tests for AppDiscovery.clean_exec, build_launch_args, and is_windows_lnk_entry."""
 
-import sys
-from unittest.mock import MagicMock, patch
-
-# Stub PyQt6 before any src imports
-for mod in ["PyQt6", "PyQt6.QtWidgets", "PyQt6.QtCore", "PyQt6.QtGui", "PyQt6.QtNetwork", "PyQt6.Qsci"]:
-    sys.modules[mod] = MagicMock()
+from unittest.mock import patch
 
 import pytest
 
-from src.modules.app_discovery import AppDiscovery, AppEntry
+from modules.app_discovery import AppDiscovery, AppEntry
 
 
 # ---------------------------------------------------------------------------
@@ -66,14 +61,14 @@ def test_build_launch_args_terminal_with_emulator():
     def which_side_effect(candidate):
         return "/usr/bin/xterm" if candidate == "xterm" else None
 
-    with patch("src.modules.app_discovery.shutil.which", side_effect=which_side_effect):
+    with patch("modules.app_discovery.shutil.which", side_effect=which_side_effect):
         result = AppDiscovery.build_launch_args(entry)
     assert result == ["/usr/bin/xterm", "-e", "htop"]
 
 
 def test_build_launch_args_terminal_no_emulator():
     entry = AppEntry(name="Htop", exec_cmd="htop", terminal=True, icon_name="")
-    with patch("src.modules.app_discovery.shutil.which", return_value=None):
+    with patch("modules.app_discovery.shutil.which", return_value=None):
         result = AppDiscovery.build_launch_args(entry)
     assert result is None
 
@@ -87,7 +82,7 @@ def test_build_launch_args_terminal_second_emulator():
         candidates_tried.append(candidate)
         return "/usr/bin/konsole" if candidate == "konsole" else None
 
-    with patch("src.modules.app_discovery.shutil.which", side_effect=which_side_effect):
+    with patch("modules.app_discovery.shutil.which", side_effect=which_side_effect):
         result = AppDiscovery.build_launch_args(entry)
 
     assert result == ["/usr/bin/konsole", "-e", "htop"]
@@ -107,20 +102,20 @@ def test_build_launch_args_shlex_error_fallback():
 
 def test_is_windows_lnk_entry_lnk_path():
     entry = AppEntry(name="App", exec_cmd=r"C:\Users\user\AppData\Roaming\App.lnk", terminal=False, icon_name="")
-    with patch("src.modules.app_discovery.IS_WINDOWS", True):
+    with patch("modules.app_discovery.IS_WINDOWS", True):
         result = AppDiscovery.is_windows_lnk_entry(entry)
     assert result is True
 
 
 def test_is_windows_lnk_entry_non_lnk_path():
     entry = AppEntry(name="Firefox", exec_cmd="/usr/bin/firefox", terminal=False, icon_name="")
-    with patch("src.modules.app_discovery.IS_WINDOWS", True):
+    with patch("modules.app_discovery.IS_WINDOWS", True):
         result = AppDiscovery.is_windows_lnk_entry(entry)
     assert result is False
 
 
 def test_is_windows_lnk_entry_linux_always_false():
     entry = AppEntry(name="App", exec_cmd="some_app.lnk", terminal=False, icon_name="")
-    with patch("src.modules.app_discovery.IS_WINDOWS", False):
+    with patch("modules.app_discovery.IS_WINDOWS", False):
         result = AppDiscovery.is_windows_lnk_entry(entry)
     assert result is False

--- a/tests/test_app_discovery.py
+++ b/tests/test_app_discovery.py
@@ -1,0 +1,126 @@
+"""Tests for AppDiscovery.clean_exec, build_launch_args, and is_windows_lnk_entry."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+# Stub PyQt6 before any src imports
+for mod in ["PyQt6", "PyQt6.QtWidgets", "PyQt6.QtCore", "PyQt6.QtGui", "PyQt6.QtNetwork", "PyQt6.Qsci"]:
+    sys.modules[mod] = MagicMock()
+
+import pytest
+
+from src.modules.app_discovery import AppDiscovery, AppEntry
+
+
+# ---------------------------------------------------------------------------
+# clean_exec
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("placeholder", ["%f", "%F", "%u", "%U", "%i", "%c", "%k"])
+def test_clean_exec_placeholder_removal_individual(placeholder):
+    result = AppDiscovery.clean_exec(f"gedit {placeholder}")
+    assert placeholder not in result
+    assert "gedit" in result
+
+
+def test_clean_exec_multiple_placeholders():
+    result = AppDiscovery.clean_exec("gedit %F %U %i")
+    assert result == "gedit"
+
+
+def test_clean_exec_no_placeholders():
+    result = AppDiscovery.clean_exec("gedit /tmp/file.txt")
+    assert result == "gedit /tmp/file.txt"
+
+
+def test_clean_exec_only_placeholders_returns_empty():
+    result = AppDiscovery.clean_exec("%F %U")
+    assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# build_launch_args
+# ---------------------------------------------------------------------------
+
+def test_build_launch_args_non_terminal():
+    entry = AppEntry(name="Gedit", exec_cmd="gedit %F", terminal=False, icon_name="")
+    result = AppDiscovery.build_launch_args(entry)
+    assert result == ["gedit"]
+
+
+def test_build_launch_args_empty_after_clean():
+    entry = AppEntry(name="Bad", exec_cmd="%F %U", terminal=False, icon_name="")
+    result = AppDiscovery.build_launch_args(entry)
+    assert result is None
+
+
+def test_build_launch_args_multi_token():
+    entry = AppEntry(name="Env", exec_cmd="env DISPLAY=:0 gedit", terminal=False, icon_name="")
+    result = AppDiscovery.build_launch_args(entry)
+    assert result == ["env", "DISPLAY=:0", "gedit"]
+
+
+def test_build_launch_args_terminal_with_emulator():
+    entry = AppEntry(name="Htop", exec_cmd="htop", terminal=True, icon_name="")
+
+    def which_side_effect(candidate):
+        return "/usr/bin/xterm" if candidate == "xterm" else None
+
+    with patch("src.modules.app_discovery.shutil.which", side_effect=which_side_effect):
+        result = AppDiscovery.build_launch_args(entry)
+    assert result == ["/usr/bin/xterm", "-e", "htop"]
+
+
+def test_build_launch_args_terminal_no_emulator():
+    entry = AppEntry(name="Htop", exec_cmd="htop", terminal=True, icon_name="")
+    with patch("src.modules.app_discovery.shutil.which", return_value=None):
+        result = AppDiscovery.build_launch_args(entry)
+    assert result is None
+
+
+def test_build_launch_args_terminal_second_emulator():
+    entry = AppEntry(name="Htop", exec_cmd="htop", terminal=True, icon_name="")
+    # x-terminal-emulator first, gnome-terminal second — make konsole succeed
+    candidates_tried = []
+
+    def which_side_effect(candidate):
+        candidates_tried.append(candidate)
+        return "/usr/bin/konsole" if candidate == "konsole" else None
+
+    with patch("src.modules.app_discovery.shutil.which", side_effect=which_side_effect):
+        result = AppDiscovery.build_launch_args(entry)
+
+    assert result == ["/usr/bin/konsole", "-e", "htop"]
+    # konsole is not the first candidate, so first candidates should have returned None
+    assert candidates_tried.index("konsole") > 0
+
+
+def test_build_launch_args_shlex_error_fallback():
+    entry = AppEntry(name="Bad", exec_cmd="app 'unclosed", terminal=False, icon_name="")
+    result = AppDiscovery.build_launch_args(entry)
+    assert result == ["app 'unclosed"]
+
+
+# ---------------------------------------------------------------------------
+# is_windows_lnk_entry
+# ---------------------------------------------------------------------------
+
+def test_is_windows_lnk_entry_lnk_path():
+    entry = AppEntry(name="App", exec_cmd=r"C:\Users\user\AppData\Roaming\App.lnk", terminal=False, icon_name="")
+    with patch("src.modules.app_discovery.IS_WINDOWS", True):
+        result = AppDiscovery.is_windows_lnk_entry(entry)
+    assert result is True
+
+
+def test_is_windows_lnk_entry_non_lnk_path():
+    entry = AppEntry(name="Firefox", exec_cmd="/usr/bin/firefox", terminal=False, icon_name="")
+    with patch("src.modules.app_discovery.IS_WINDOWS", True):
+        result = AppDiscovery.is_windows_lnk_entry(entry)
+    assert result is False
+
+
+def test_is_windows_lnk_entry_linux_always_false():
+    entry = AppEntry(name="App", exec_cmd="some_app.lnk", terminal=False, icon_name="")
+    with patch("src.modules.app_discovery.IS_WINDOWS", False):
+        result = AppDiscovery.is_windows_lnk_entry(entry)
+    assert result is False

--- a/tests/test_single_instance.py
+++ b/tests/test_single_instance.py
@@ -1,3 +1,14 @@
+# [ORCHESTRATOR NOTE] Pre-existing failure — unrelated to issue #48
+# Failure: AttributeError: type object 'MagicMock' has no attribute 'instance'
+#   in pytestqt/plugin.py when pytest-qt tries QApplication.instance() after
+#   the test because sys.modules["PyQt6"] is a MagicMock (set by this file's
+#   PyQt6 stub) and pytest-qt's teardown assumes a real QApplication.
+# Suggested fix: Use a more targeted stub that sets QApplication.instance()
+#   to return None (e.g. sys.modules["PyQt6"].QtWidgets.QApplication.instance.return_value = None)
+#   or configure pytest.ini with qt_api=pyqt5 so pytest-qt uses PyQt5 instead
+#   of the stubbed PyQt6. Alternatively add @pytest.mark.no_qt_log marker or
+#   use conftest.py to reconfigure the qt plugin for this module.
+
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Tests for SingleInstanceChecker.
 

--- a/tests/test_single_instance.py
+++ b/tests/test_single_instance.py
@@ -1,14 +1,3 @@
-# [ORCHESTRATOR NOTE] Pre-existing failure — unrelated to issue #48
-# Failure: AttributeError: type object 'MagicMock' has no attribute 'instance'
-#   in pytestqt/plugin.py when pytest-qt tries QApplication.instance() after
-#   the test because sys.modules["PyQt6"] is a MagicMock (set by this file's
-#   PyQt6 stub) and pytest-qt's teardown assumes a real QApplication.
-# Suggested fix: Use a more targeted stub that sets QApplication.instance()
-#   to return None (e.g. sys.modules["PyQt6"].QtWidgets.QApplication.instance.return_value = None)
-#   or configure pytest.ini with qt_api=pyqt5 so pytest-qt uses PyQt5 instead
-#   of the stubbed PyQt6. Alternatively add @pytest.mark.no_qt_log marker or
-#   use conftest.py to reconfigure the qt plugin for this module.
-
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Tests for SingleInstanceChecker.
 
@@ -31,15 +20,6 @@ SRC_DIR = PROJECT_ROOT / "src"
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
-# [ORCHESTRATOR NOTE] Pre-existing failure — unrelated to issue #41
-# Failure: All 15 tests in this file ERROR at setup/teardown with
-#   AttributeError: type object 'MagicMock' has no attribute 'instance'
-# Root cause: pytest-qt plugin calls QApplication.instance() during setup/teardown.
-#   The PyQt6.QtWidgets stub installed here is a plain types.ModuleType with no
-#   QApplication attribute, so pytest-qt's _process_events() crashes.
-# Suggested fix: Add QApplication = MagicMock() to the PyQt6.QtWidgets stub below,
-#   or add 'qt_api = "pyqt6"' to pyproject.toml [tool.pytest.ini_options] and
-#   install a real PyQt6 (or use pytest -p no:qt for non-GUI test files).
 # Stub PyQt6 symbols that single_instance.py imports at module level.
 for _mod in ["PyQt6", "PyQt6.QtCore", "PyQt6.QtWidgets"]:
     if _mod not in sys.modules:
@@ -69,17 +49,6 @@ def _make_checker(key="test-key", pidfile=None):
 # is_pid_running
 # ---------------------------------------------------------------------------
 
-# [ORCHESTRATOR NOTE] Pre-existing failure — unrelated to issue #37
-# Failure: AttributeError: type object 'MagicMock' has no attribute 'instance'
-#   pytest-qt's _process_events() hook fires around every test and calls
-#   QtWidgets.QApplication.instance(). The PyQt6 MagicMock stub in conftest
-#   does not satisfy pytestqt's expectation that QApplication is a real
-#   class-like object with a callable .instance class method.
-# Suggested fix: In conftest.py, after injecting the PyQt6 stub, patch
-#   pytestqt.plugin._process_events with a no-op lambda so the hook never
-#   tries to process Qt events:
-#     import pytestqt.plugin; pytestqt.plugin._process_events = lambda: None
-#   This is safe because no test in this file uses a real QApplication.
 class TestIsPidRunning:
     def test_own_pid_is_running(self):
         checker = _make_checker()


### PR DESCRIPTION
## Summary
Resolves #48 — BUG: Add unit tests for AppDiscovery.build_launch_args and clean_exec

**Project:** [Py tray launcher project](#8) — _Backlog_
## Changes
- No test file for AppDiscovery exec pipeline
- clean_exec: %- placeholder stripping not verified
- build_launch_args: Terminal=False path untested
- build_launch_args: Terminal=True with emulator found untested
- build_launch_args: Terminal=True with no emulator on PATH untested
- build_launch_args: shlex.split ValueError fallback untested
- is_windows_lnk_entry: .lnk and non-.lnk paths untested

**Tasks:**
- Create `tests/test_app_discovery.py` with module-level PyQt6 stub via
- Add necessary imports: `pytest`, `unittest.mock.patch`, `AppDiscovery`,
- Parametrize `test_clean_exec_placeholder_removal` covering `%f`, `%F`,
- Add parametrize case for multiple placeholders in one `exec_cmd` string
- Add parametrize case for a clean exec string with no placeholders —
- Add parametrize case for exec string that is *only* placeholders —
- Test `Terminal=False` with a normal exec: `"gedit %F"` → `["gedit"]`
- Test `Terminal=False` where exec becomes empty after `clean_exec` (all
- Test `Terminal=False` with a multi-token exec: `"env DISPLAY=:0 gedit"`
- Test `Terminal=True` with `shutil.which` returning a path for `"xterm"`:
- Test `Terminal=True` with `shutil.which` returning `None` for every
- Test `Terminal=True` with the first candidate failing and the second
- Test that an exec value with an unmatched quote (`"app 'unclosed"`)
- Test `IS_WINDOWS=True`, `exec_cmd` ends with `.lnk`: returns `True`;
- Test `IS_WINDOWS=True`, `exec_cmd` does NOT end with `.lnk`: returns
- Test `IS_WINDOWS=False`, `exec_cmd` ends with `.lnk`: returns `False`
- Run `pytest --cov=src/modules/app_discovery tests/test_app_discovery.py`
- Confirm all new tests pass in CI (`pytest tests/test_app_discovery.py`)
## Testing
Run the full test suite — all tests must pass.
Closes #48