### PR TITLE
fix: resolve #50 - FEATURE: Cache terminal emulator lookup in build_launch_args

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,5 @@ config/backups
 # AI
 .understand-anything/intermediate/
 .understand-anything/diff-overlay.json.hermes_tmp_prompt.txt
+# workspace-orchestrator managed entries
+graphify-out/cache/

--- a/src/modules/app_discovery.py
+++ b/src/modules/app_discovery.py
@@ -13,6 +13,7 @@ Public API
 """
 
 import configparser
+import functools
 import logging
 import os
 import re
@@ -59,6 +60,20 @@ _TERMINAL_EMULATORS = [
     "alacritty",
     "kitty",
 ]
+
+
+@functools.lru_cache(maxsize=1)
+def _find_terminal_emulator() -> str | None:
+    """Return the path of the first available terminal emulator, or None.
+
+    Result is cached for the process lifetime. Call
+    ``_find_terminal_emulator.cache_clear()`` in tests to reset the cache
+    between cases.
+    """
+    return next(
+        (shutil.which(c) for c in _TERMINAL_EMULATORS if shutil.which(c)),
+        None,
+    )
 
 
 @dataclass
@@ -451,12 +466,7 @@ class AppDiscovery:
             return None
 
         if entry.terminal:
-            terminal = None
-            for candidate in _TERMINAL_EMULATORS:
-                found = shutil.which(candidate)
-                if found:
-                    terminal = found
-                    break
+            terminal = _find_terminal_emulator()
             if terminal is None:
                 logger.warning(
                     "No terminal emulator found for terminal app %s", entry.name

--- a/src/modules/app_discovery.py
+++ b/src/modules/app_discovery.py
@@ -416,8 +416,18 @@ class AppDiscovery:
         return re.sub(r'%[fFuUdDnNickv]', '', exec_cmd).strip()
 
     @staticmethod
-    def build_launch_args(entry: AppEntry) -> list[str] | None:
+    def build_launch_args(entry: "AppEntry") -> list[str] | None:
         """Build the argv list for launching *entry*.
+
+        Uses a two-level fallback strategy to parse the Exec= value:
+
+        1. ``shlex.split`` — handles quoted arguments correctly.
+        2. Whitespace split (``str.split()``) — used when ``shlex.split`` fails
+           due to unmatched quotes or other shell-syntax errors.  This is a
+           deliberate trade-off: we lose quote-grouping semantics but avoid
+           silently wrapping the entire command string as a single token.
+        3. ``None`` — returned when the cleaned Exec= string is empty or
+           produces no tokens after the fallback split.
 
         Handles ``Terminal=true`` by prepending a detected terminal emulator.
         Returns ``None`` if no terminal emulator can be found for terminal apps.
@@ -428,8 +438,17 @@ class AppDiscovery:
         try:
             args = shlex.split(cleaned)
         except ValueError as exc:
-            logger.warning("Failed to parse Exec for %s: %s", entry.name, exc)
-            args = [cleaned]
+            logger.warning(
+                "shlex.split failed for %s (%s); falling back to whitespace split",
+                entry.name,
+                exc,
+            )
+            # Deliberate trade-off: whitespace split loses quote-grouping but
+            # avoids silently treating the entire command string as one token,
+            # which would cause FileNotFoundError at Popen time.
+            args = cleaned.split()
+        if not args:
+            return None
 
         if entry.terminal:
             terminal = None

--- a/src/modules/app_discovery.py
+++ b/src/modules/app_discovery.py
@@ -70,10 +70,11 @@ def _find_terminal_emulator() -> str | None:
     ``_find_terminal_emulator.cache_clear()`` in tests to reset the cache
     between cases.
     """
-    return next(
-        (shutil.which(c) for c in _TERMINAL_EMULATORS if shutil.which(c)),
-        None,
-    )
+    for candidate in _TERMINAL_EMULATORS:
+        found = shutil.which(candidate)
+        if found:
+            return found
+    return None
 
 
 @dataclass

--- a/src/ui/command_palette.py
+++ b/src/ui/command_palette.py
@@ -337,6 +337,14 @@ class _PaletteWindow(QWidget):
             logger.info("Launched app: %s", entry.name)
         except OSError as exc:
             logger.warning("Failed to launch %s: %s", entry.name, exc)
+            try:
+                tray = self._palette._services.tray_icon
+                tray.showMessage(
+                    "Launch failed",
+                    f"Could not start {entry.name}: {exc}",
+                )
+            except Exception:  # noqa: BLE001 — best-effort notification
+                pass
 
     # ------------------------------------------------------------------
     # Keyboard navigation

--- a/src/ui/command_palette.py
+++ b/src/ui/command_palette.py
@@ -338,13 +338,12 @@ class _PaletteWindow(QWidget):
         except OSError as exc:
             logger.warning("Failed to launch %s: %s", entry.name, exc)
             try:
-                tray = self._palette._services.tray_icon
-                tray.showMessage(
+                self._palette._services.show_output(
                     "Launch failed",
                     f"Could not start {entry.name}: {exc}",
                 )
-            except Exception:  # noqa: BLE001 — best-effort notification
-                pass
+            except Exception as notify_exc:  # noqa: BLE001 — best-effort notification
+                logger.debug("Failed to display launch failure output: %s", notify_exc)
 
     # ------------------------------------------------------------------
     # Keyboard navigation

--- a/tests/test_app_discovery.py
+++ b/tests/test_app_discovery.py
@@ -2,15 +2,7 @@
 
 """Tests for app_discovery module — build_launch_args fallback behaviour."""
 
-# [ORCHESTRATOR NOTE] Pre-existing failure — unrelated to issue #49
-# Failure: All tests show ERROR when run via `pytest` (full suite) due to a
-#   pre-existing PyQt/pytest-qt plugin conflict that affects every test file in
-#   the project (baseline: 232 errors before any issue #49 changes). Tests pass
-#   correctly in isolation: `pytest tests/test_app_discovery.py` → 2 passed.
-# Suggested fix: Investigate pyproject.toml pytest configuration; the pytest-qt
-#   plugin likely conflicts with sys.modules PyQt6 stubs used across test files.
-#   Consider adding `qt_api = "pyqt5"` to [tool.pytest.ini_options] or disabling
-#   the qt plugin for unit-test runs.
+# Note: PyQt6 is stubbed in tests/conftest.py so tests can run headlessly without PyQt6 installed.
 
 import sys
 from pathlib import Path

--- a/tests/test_app_discovery.py
+++ b/tests/test_app_discovery.py
@@ -2,6 +2,16 @@
 
 """Tests for app_discovery module — build_launch_args fallback behaviour."""
 
+# [ORCHESTRATOR NOTE] Pre-existing failure — unrelated to issue #49
+# Failure: All tests show ERROR when run via `pytest` (full suite) due to a
+#   pre-existing PyQt/pytest-qt plugin conflict that affects every test file in
+#   the project (baseline: 232 errors before any issue #49 changes). Tests pass
+#   correctly in isolation: `pytest tests/test_app_discovery.py` → 2 passed.
+# Suggested fix: Investigate pyproject.toml pytest configuration; the pytest-qt
+#   plugin likely conflicts with sys.modules PyQt6 stubs used across test files.
+#   Consider adding `qt_api = "pyqt5"` to [tool.pytest.ini_options] or disabling
+#   the qt plugin for unit-test runs.
+
 import sys
 from pathlib import Path
 import unittest

--- a/tests/test_app_discovery.py
+++ b/tests/test_app_discovery.py
@@ -64,5 +64,56 @@ class TestBuildLaunchArgsFallback(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class TestFindTerminalEmulatorCache(unittest.TestCase):
+    """Tests for issue #50 — cached terminal emulator lookup."""
+
+    def setUp(self):
+        # Import here so the function exists after implementation
+        from modules.app_discovery import _find_terminal_emulator
+        self._find_terminal_emulator = _find_terminal_emulator
+
+    def tearDown(self):
+        self._find_terminal_emulator.cache_clear()
+
+    def test_shutil_which_called_only_once_across_multiple_build_launch_args(self):
+        """shutil.which must be called at most once per process (cache hit on 2nd call)."""
+        import unittest.mock as mock
+        from modules import app_discovery as _mod
+
+        entry = _make_entry("/usr/bin/app --flag", terminal=True)
+
+        with mock.patch.object(_mod.shutil, "which", return_value="/usr/bin/xterm") as mock_which:
+            self._find_terminal_emulator.cache_clear()
+            AppDiscovery.build_launch_args(entry)
+            AppDiscovery.build_launch_args(entry)
+            # which should only be called for terminal emulator lookup once total
+            # (called once per candidate until found, but not repeated across invocations)
+            calls_after_two_invocations = mock_which.call_count
+            # Reset and run single invocation to compare
+            self._find_terminal_emulator.cache_clear()
+            mock_which.reset_mock()
+            AppDiscovery.build_launch_args(entry)
+            calls_single = mock_which.call_count
+
+        self.assertEqual(
+            calls_after_two_invocations,
+            calls_single,
+            "shutil.which should be called the same number of times for 2 invocations as 1 (cache hit)",
+        )
+
+    def test_build_launch_args_returns_none_when_no_terminal_emulator_found(self):
+        """When no terminal emulator is found, build_launch_args returns None without raising."""
+        import unittest.mock as mock
+        from modules import app_discovery as _mod
+
+        entry = _make_entry("/usr/bin/app", terminal=True)
+        self._find_terminal_emulator.cache_clear()
+
+        with mock.patch.object(_mod.shutil, "which", return_value=None):
+            result = AppDiscovery.build_launch_args(entry)
+
+        self.assertIsNone(result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_app_discovery.py
+++ b/tests/test_app_discovery.py
@@ -35,7 +35,7 @@ def _make_entry(exec_cmd: str, name: str = "TestApp", terminal: bool = False) ->
 
 
 class TestBuildLaunchArgsFallback(unittest.TestCase):
-    """Tests for two-level fallback in build_launch_args (issue #49)."""
+    """Tests for two-level fallback in build_launch_args."""
 
     def test_build_launch_args_unmatched_quote_falls_back_to_whitespace_split(self):
         """Exec= with unmatched quote must fall back to whitespace split, not single token."""

--- a/tests/test_app_discovery.py
+++ b/tests/test_app_discovery.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Tests for app_discovery module — build_launch_args fallback behaviour."""
+
+import sys
+from pathlib import Path
+import unittest
+from unittest.mock import MagicMock
+
+# Stub PyQt6 before importing any src modules
+_pyqt6_stub = MagicMock()
+sys.modules.setdefault("PyQt6", _pyqt6_stub)
+sys.modules.setdefault("PyQt6.QtCore", _pyqt6_stub.QtCore)
+sys.modules.setdefault("PyQt6.QtWidgets", _pyqt6_stub.QtWidgets)
+sys.modules.setdefault("PyQt6.QtGui", _pyqt6_stub.QtGui)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from modules.app_discovery import AppDiscovery, AppEntry  # noqa: E402
+
+
+def _make_entry(exec_cmd: str, name: str = "TestApp", terminal: bool = False) -> AppEntry:
+    entry = AppEntry.__new__(AppEntry)
+    entry.name = name
+    entry.exec_cmd = exec_cmd
+    entry.icon_name = ""
+    entry.categories = []
+    entry.terminal = terminal
+    return entry
+
+
+class TestBuildLaunchArgsFallback(unittest.TestCase):
+    """Tests for two-level fallback in build_launch_args (issue #49)."""
+
+    def test_build_launch_args_unmatched_quote_falls_back_to_whitespace_split(self):
+        """Exec= with unmatched quote must fall back to whitespace split, not single token."""
+        entry = _make_entry("/usr/bin/app --flag 'bad")
+        result = AppDiscovery.build_launch_args(entry)
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, list)
+        self.assertGreater(len(result), 1, "Expected multiple tokens, got single-token fallback")
+        self.assertEqual(result[0], "/usr/bin/app")
+
+    def test_build_launch_args_empty_after_failed_shlex_returns_none(self):
+        """Exec= that becomes empty/whitespace after field-code stripping returns None."""
+        # Use an exec_cmd whose field codes strip to whitespace; shlex will also
+        # fail on unmatched quote so we combine both — but the simplest case is
+        # a purely whitespace exec_cmd after cleaning.
+        entry = _make_entry("   ")
+        result = AppDiscovery.build_launch_args(entry)
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Resolves #50 — FEATURE: Cache terminal emulator lookup in build_launch_args to avoid repeated PATH scans

**Project:** [Py tray launcher project](#8) — _Backlog_
## Changes
- Repeated shutil.which Scan in build_launch_args

**Tasks:**
- Add `import functools` to the import block in `src/modules/app_discovery.py`
- Add the `_find_terminal_emulator` function decorated with
- Include a docstring on `_find_terminal_emulator` explaining the caching
- Replace the inline `for candidate in _TERMINAL_EMULATORS` loop in
- Retain the existing `logger.warning` and `return None` path for when no
- Add a test that mocks `shutil.which` and verifies it is called only once
- Call `_find_terminal_emulator.cache_clear()` in the test teardown (or via
- Add a test asserting that when no terminal emulator is found,
- Verify all existing `build_launch_args` tests continue to pass after the
- Run `python3 -m py_compile src/modules/app_discovery.py` — must exit 0
- Run the full test suite (`pytest`) — must be green with no regressions
## Testing
Run the full test suite — all tests must pass.
Closes #50