### PR TITLE
ci: add pip-audit dependency vulnerability scanning to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,3 +17,14 @@ jobs:
       - run: pip install ruff
       - run: ruff check src/
       - run: ruff format --check src/
+
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - run: pip install pip-audit
+      - run: pip install -e ".[dev]"
+      - run: pip-audit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,6 +47,8 @@ jobs:
 
   pip-audit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
       - run: pip install pip-audit
       - run: pip install -e ".[dev]"
       - run: pip-audit

--- a/README.md
+++ b/README.md
@@ -194,6 +194,14 @@ without verifying the file length (16 bytes = legacy, 20 bytes = current).
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for linting setup, noqa suppression conventions, and development workflow. For broader setup instructions and documentation policy, see [docs/contributing.md](docs/contributing.md).
 
+### Dependency updates
+
+Dependency version updates are managed automatically by Dependabot (`.github/dependabot.yml`),
+which opens pull requests for outdated pip packages every Monday.
+A `pip-audit` step in the lint workflow scans all installed packages for known CVEs on every
+push and pull request. When merging a Dependabot PR, confirm the audit step passes before
+approving.
+
 ---
 
 ## License


### PR DESCRIPTION
## Summary

Issue #71 identified a gap in the security posture of this repository: while Dependabot is already configured to surface outdated pip packages, there was no active scan for known CVEs against the currently installed dependency versions. The `cryptography` package in particular has a documented CVE history. This change closes that gap by adding `pip-audit` to CI, ensuring every push and pull request is checked against known vulnerability databases.

## Changes

**.github/workflows/lint.yml — new `pip-audit` job**

A dedicated `pip-audit` job was added to the existing lint workflow. It installs the project in editable mode (including dev dependencies) and runs `pip-audit` against the full resolved environment. Running it as a separate job keeps lint and security concerns independently reportable in the Actions UI, and avoids failing the ruff linting job on unrelated security findings.

The `pip-audit` job also uses pip caching via `actions/setup-python` and sets read-only `contents` permissions for least-privilege hardening.

**README.md — Dependency updates section**

A new subsection under "Contributing" documents the automated dependency management policy: Dependabot opens PRs weekly, and the `pip-audit` CI step guards every push. This ensures contributors and reviewers know what automation is in place and what to check before merging Dependabot PRs.

## Testing

1. Push this branch — confirm both the `lint` and `pip-audit` jobs appear and pass in GitHub Actions.
2. Inspect the `pip-audit` step output to verify it scans all installed packages and reports no known CVEs against the current dependency set.
3. To simulate a failure locally: `pip install pip-audit && pip install -e ".[dev]" && pip-audit`.
4. Verify README renders correctly on GitHub — the new "Dependency updates" subsection should appear under "Contributing".