### PR TITLE
fix: resolve #70 - BUG: Add migration path and user notification for files encr

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -117,6 +117,16 @@ Encrypt and decrypt files or entire folders using a password-derived key (PBKDF2
 
 Encryption runs in a background thread so the UI stays responsive on large files or directories. Progress is shown via a progress bar.
 
+### Salt Format and Migration
+
+Each encrypted file is accompanied by a `.salt` file that stores the parameters needed for decryption.
+
+**Current format (20 bytes):** a 4-byte big-endian `uint32` holding the PBKDF2 iteration count (currently 600 000) followed by 16 bytes of random salt.
+
+**Legacy format (16 bytes):** files encrypted before the iteration-count upgrade contain only the 16-byte salt. The application automatically recognises this format and uses the original 100 000 iteration count for decryption.
+
+**In-app upgrade path:** after successfully decrypting a legacy file, the application offers to re-encrypt it using the current standard (600 000 iterations). Accepting the prompt opens a password dialog; the re-encryption is performed atomically — new encrypted and salt files are written to temporary files first, then renamed into place, so the original plaintext is never removed unless both writes succeed.
+
 ---
 
 ## Command Scheduling

--- a/src/modules/file_encryptor.py
+++ b/src/modules/file_encryptor.py
@@ -240,7 +240,7 @@ class EncryptionWorker(QThread):
                     successful_operations,
                     total_files,
                 )
-                if self.operation == "decrypt" and is_legacy:
+                if self.operation == "decrypt" and is_legacy and not self.is_folder:
                     decrypted_output = (
                         self.file_path[: -len(ENC_FILE_SUFFIX)]
                         if self.file_path.endswith(ENC_FILE_SUFFIX)
@@ -533,7 +533,7 @@ class FileEncryptor:
         enc_path = file_path + ENC_FILE_SUFFIX
         salt_path = file_path + SALT_FILE_SUFFIX
         try:
-            password_dialog = PasswordDialog("re-encrypt", file_path)
+            password_dialog = PasswordDialog("re-encrypt")
             if password_dialog.exec() != QDialog.DialogCode.Accepted:
                 return
             password = password_dialog.get_password()

--- a/src/modules/file_encryptor.py
+++ b/src/modules/file_encryptor.py
@@ -39,6 +39,7 @@ class EncryptionWorker(QThread):
     progress_updated = pyqtSignal(int)
     status_updated = pyqtSignal(str)
     finished_signal = pyqtSignal(bool, str)  # success, message
+    legacy_detected = pyqtSignal(str)  # decrypted output path
 
     def __init__(self, operation, file_path, password, is_folder=False):
         super().__init__()
@@ -143,6 +144,7 @@ class EncryptionWorker(QThread):
     def run(self):
         """Run the encryption/decryption operation."""
         logger.info("Starting %s operation on: %s", self.operation, self.file_path)
+        is_legacy = False
         try:
             # Generate salt
             salt = os.urandom(16)
@@ -197,6 +199,7 @@ class EncryptionWorker(QThread):
                         # Legacy format: 16-byte salt only — iteration count was 100 000
                         stored_iterations = _LEGACY_ITERATIONS
                         salt = raw
+                        is_legacy = True
                     else:
                         self.finished_signal.emit(
                             False, "Salt file is corrupt or unrecognised format. Cannot decrypt."
@@ -237,6 +240,13 @@ class EncryptionWorker(QThread):
                     successful_operations,
                     total_files,
                 )
+                if self.operation == "decrypt" and is_legacy:
+                    decrypted_output = (
+                        self.file_path[: -len(ENC_FILE_SUFFIX)]
+                        if self.file_path.endswith(ENC_FILE_SUFFIX)
+                        else self.file_path
+                    )
+                    self.legacy_detected.emit(decrypted_output)
                 self.finished_signal.emit(True, message)
             else:
                 operation_name = "encryption" if self.operation == "encrypt" else "decryption"
@@ -468,12 +478,14 @@ class FileEncryptor:
 
     def _process_file(self, file_path, password, operation, is_folder):
         """Process file/folder with progress dialog."""
+        self._legacy_decrypted_path = None
         progress_dialog = ProgressDialog(operation, file_path)
 
         # Create worker thread
         self.worker = EncryptionWorker(operation, file_path, password, is_folder)
         self.worker.progress_updated.connect(progress_dialog.update_progress)
         self.worker.status_updated.connect(progress_dialog.update_status)
+        self.worker.legacy_detected.connect(self._on_legacy_detected)
         self.worker.finished_signal.connect(
             lambda success, message: self._on_operation_finished(progress_dialog, success, message)
         )
@@ -482,6 +494,10 @@ class FileEncryptor:
         self.worker.start()
         progress_dialog.exec()
 
+    def _on_legacy_detected(self, decrypted_path: str) -> None:
+        """Store the decrypted path from a legacy-encrypted file for upgrade prompt."""
+        self._legacy_decrypted_path = decrypted_path
+
     def _on_operation_finished(self, progress_dialog, success, message):
         """Handle operation completion."""
         progress_dialog.disable_cancel()
@@ -489,5 +505,71 @@ class FileEncryptor:
 
         if success:
             QMessageBox.information(None, "Success", message)
+            if self._legacy_decrypted_path:
+                legacy_path = self._legacy_decrypted_path
+                self._legacy_decrypted_path = None
+                reply = QMessageBox.question(
+                    None,
+                    "Legacy Encryption Detected",
+                    "This file was encrypted with a legacy key (100\u202f000 iterations).\n"
+                    "Re-encrypt now to upgrade to the current standard (600\u202f000 iterations)?",
+                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                    QMessageBox.StandardButton.No,
+                )
+                if reply == QMessageBox.StandardButton.Yes:
+                    self._reencrypt_to_current_standard(legacy_path)
         else:
             QMessageBox.warning(None, "Error", message)
+
+    def _reencrypt_to_current_standard(self, file_path: str) -> None:
+        """Re-encrypt a plaintext file using current KDF parameters (600 000 iterations).
+
+        Operates atomically: writes to temp files first, then os.replace() into final
+        positions. The original plaintext file is not removed until both temp files have
+        been written successfully.
+        """
+        import tempfile
+
+        enc_path = file_path + ENC_FILE_SUFFIX
+        salt_path = file_path + SALT_FILE_SUFFIX
+        try:
+            password_dialog = PasswordDialog("re-encrypt", file_path)
+            if password_dialog.exec() != QDialog.DialogCode.Accepted:
+                return
+            password = password_dialog.get_password()
+
+            salt = os.urandom(16)
+            key = EncryptionWorker("encrypt", file_path, password)._derive_key(
+                password, salt, iterations=_PBKDF2_ITERATIONS
+            )
+
+            with open(file_path, "rb") as fh:
+                plaintext = fh.read()
+
+            fernet = Fernet(key)
+            ciphertext = fernet.encrypt(plaintext)
+
+            dir_ = os.path.dirname(file_path) or "."
+            with tempfile.NamedTemporaryFile(dir=dir_, delete=False, suffix=".enc.tmp") as enc_tmp:
+                enc_tmp.write(ciphertext)
+                enc_tmp_path = enc_tmp.name
+
+            with tempfile.NamedTemporaryFile(dir=dir_, delete=False, suffix=".salt.tmp") as salt_tmp:
+                salt_tmp.write(struct.pack(">I", _PBKDF2_ITERATIONS))
+                salt_tmp.write(salt)
+                salt_tmp_path = salt_tmp.name
+
+            os.replace(enc_tmp_path, enc_path)
+            os.replace(salt_tmp_path, salt_path)
+            os.remove(file_path)
+
+            QMessageBox.information(None, "Re-encrypted", "File upgraded to current encryption standard.")
+        except Exception as exc:
+            logger.error("Re-encryption failed: %s", exc)
+            QMessageBox.warning(None, "Re-encryption Failed", f"Could not re-encrypt file: {exc}")
+            for tmp in [locals().get("enc_tmp_path"), locals().get("salt_tmp_path")]:
+                if tmp and os.path.exists(tmp):
+                    try:
+                        os.remove(tmp)
+                    except OSError:
+                        pass

--- a/tests/test_file_encryptor.py
+++ b/tests/test_file_encryptor.py
@@ -2,12 +2,12 @@
 """Tests for file_encryptor — PBKDF2 iteration count and salt-file format."""
 
 import os
-import struct
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+
 
 # Stub PyQt6 so the module can be imported without a display server.
 # QThread must be a real Python class so EncryptionWorker can subclass it
@@ -140,6 +140,7 @@ class TestLegacySaltFallback(unittest.TestCase):
     def test_legacy_16_byte_salt_decrypts_correctly(self):
         """Files encrypted with the old 100 000 iteration scheme must still decrypt."""
         import base64
+
         from cryptography.fernet import Fernet
         from cryptography.hazmat.primitives import hashes
         from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
@@ -241,6 +242,7 @@ class TestLegacyDetectedSignal(unittest.TestCase):
     def _encrypt_with_legacy(self, plain_file, password):
         """Encrypt a file using legacy 100 000 iterations and 16-byte salt."""
         import base64
+
         from cryptography.fernet import Fernet
         from cryptography.hazmat.primitives import hashes
         from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
@@ -307,8 +309,8 @@ class TestReencryptToCurrentStandard(unittest.TestCase):
 
     def test_reencrypt_produces_20_byte_salt_and_enc_file(self):
         """_reencrypt_to_current_standard must produce a 20-byte .salt and .enc file."""
-        from modules.file_encryptor import ENC_FILE_SUFFIX, SALT_FILE_SUFFIX, FileEncryptor
         import modules.file_encryptor as fe_mod
+        from modules.file_encryptor import ENC_FILE_SUFFIX, SALT_FILE_SUFFIX
 
         with tempfile.TemporaryDirectory() as tmp:
             plain_file = os.path.join(tmp, "plain.txt")
@@ -316,12 +318,17 @@ class TestReencryptToCurrentStandard(unittest.TestCase):
 
             enc = self._make_encryptor()
 
+            accepted_sentinel = object()
             mock_dialog = MagicMock()
-            mock_dialog.exec.return_value = MagicMock()  # will compare to QDialog.DialogCode.Accepted
+            mock_dialog.exec.return_value = accepted_sentinel
             mock_dialog.get_password.return_value = "newpassword"
 
-            with patch.object(fe_mod, "PasswordDialog", return_value=mock_dialog) as _pd, \
-                 patch.object(fe_mod.QDialog.DialogCode, "Accepted", mock_dialog.exec.return_value):
+            mock_qdialog = MagicMock()
+            mock_qdialog.DialogCode.Accepted = accepted_sentinel
+
+            with patch.object(fe_mod, "PasswordDialog", return_value=mock_dialog), \
+                 patch.object(fe_mod, "QDialog", mock_qdialog), \
+                 patch.object(fe_mod.QMessageBox, "information"):
                 enc._reencrypt_to_current_standard(plain_file)
 
             salt_file = plain_file + SALT_FILE_SUFFIX
@@ -334,7 +341,6 @@ class TestReencryptToCurrentStandard(unittest.TestCase):
 
     def test_reencrypt_atomic_cleanup_on_rename_failure(self):
         """If rename fails after writing temp enc file, original plaintext is preserved."""
-        from modules.file_encryptor import FileEncryptor
         import modules.file_encryptor as fe_mod
 
         with tempfile.TemporaryDirectory() as tmp:
@@ -343,9 +349,13 @@ class TestReencryptToCurrentStandard(unittest.TestCase):
 
             enc = self._make_encryptor()
 
+            accepted_sentinel = object()
             mock_dialog = MagicMock()
             mock_dialog.get_password.return_value = "pw"
-            mock_dialog.exec.return_value = MagicMock()
+            mock_dialog.exec.return_value = accepted_sentinel
+
+            mock_qdialog = MagicMock()
+            mock_qdialog.DialogCode.Accepted = accepted_sentinel
 
             replace_call_count = [0]
             real_replace = os.replace
@@ -357,7 +367,7 @@ class TestReencryptToCurrentStandard(unittest.TestCase):
                 return real_replace(src, dst)
 
             with patch.object(fe_mod, "PasswordDialog", return_value=mock_dialog), \
-                 patch.object(fe_mod.QDialog.DialogCode, "Accepted", mock_dialog.exec.return_value), \
+                 patch.object(fe_mod, "QDialog", mock_qdialog), \
                  patch("os.replace", side_effect=fake_replace), \
                  patch.object(fe_mod.QMessageBox, "warning"):
                 enc._reencrypt_to_current_standard(plain_file)

--- a/tests/test_file_encryptor.py
+++ b/tests/test_file_encryptor.py
@@ -218,5 +218,157 @@ class TestCorruptSaltFile(unittest.TestCase):
             self.assertIn("corrupt", results.get("message", "").lower())
 
 
+class TestLegacyDetectedSignal(unittest.TestCase):
+    """EncryptionWorker must emit legacy_detected when a 16-byte salt is found."""
+
+    def _run_worker_decrypt(self, enc_file, password):
+        worker = EncryptionWorker("decrypt", enc_file, password)
+        worker.finished_signal = MagicMock()
+        worker.progress_updated = MagicMock()
+        worker.status_updated = MagicMock()
+        worker.legacy_detected = MagicMock()
+
+        results = {}
+
+        def on_finished(success, message):
+            results["success"] = success
+            results["message"] = message
+
+        worker.finished_signal.emit.side_effect = on_finished
+        worker.run()
+        return worker, results
+
+    def _encrypt_with_legacy(self, plain_file, password):
+        """Encrypt a file using legacy 100 000 iterations and 16-byte salt."""
+        import base64
+        from cryptography.fernet import Fernet
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+        salt = os.urandom(16)
+        kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt, iterations=_LEGACY_ITERATIONS)
+        key = base64.urlsafe_b64encode(kdf.derive(password.encode()))
+        fernet = Fernet(key)
+        plaintext = Path(plain_file).read_bytes()
+        encrypted = fernet.encrypt(plaintext)
+
+        enc_file = plain_file + ".enc"
+        salt_file = plain_file + ".salt"
+        Path(enc_file).write_bytes(encrypted)
+        Path(salt_file).write_bytes(salt)  # 16-byte legacy format
+        return enc_file
+
+    def test_legacy_detected_emitted_for_16_byte_salt(self):
+        """Worker must emit legacy_detected with decrypted path when salt is 16 bytes."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plain_file = os.path.join(tmp, "doc.txt")
+            Path(plain_file).write_bytes(b"legacy content")
+            enc_file = self._encrypt_with_legacy(plain_file, "pw")
+            # Remove the original so decrypt can write it back
+            os.remove(plain_file)
+
+            worker, results = self._run_worker_decrypt(enc_file, "pw")
+
+            self.assertTrue(results.get("success"), results.get("message"))
+            worker.legacy_detected.emit.assert_called_once()
+            emitted_path = worker.legacy_detected.emit.call_args[0][0]
+            self.assertEqual(emitted_path, plain_file)
+
+    def test_legacy_detected_not_emitted_for_20_byte_salt(self):
+        """Worker must NOT emit legacy_detected when salt file is 20 bytes (current format)."""
+        original_content = b"current content"
+        with tempfile.TemporaryDirectory() as tmp:
+            plain_file = os.path.join(tmp, "doc.txt")
+            Path(plain_file).write_bytes(original_content)
+
+            # Encrypt with current format
+            enc_worker = EncryptionWorker("encrypt", plain_file, "pw")
+            enc_worker.finished_signal = MagicMock()
+            enc_worker.progress_updated = MagicMock()
+            enc_worker.status_updated = MagicMock()
+            enc_worker.run()
+
+            enc_file = plain_file + ".enc"
+            worker, results = self._run_worker_decrypt(enc_file, "pw")
+
+            self.assertTrue(results.get("success"), results.get("message"))
+            worker.legacy_detected.emit.assert_not_called()
+
+
+class TestReencryptToCurrentStandard(unittest.TestCase):
+    """Tests for FileEncryptor._reencrypt_to_current_standard."""
+
+    def _make_encryptor(self):
+        from modules.file_encryptor import FileEncryptor
+        services = MagicMock()
+        enc = FileEncryptor.__new__(FileEncryptor)
+        enc.services = services
+        return enc
+
+    def test_reencrypt_produces_20_byte_salt_and_enc_file(self):
+        """_reencrypt_to_current_standard must produce a 20-byte .salt and .enc file."""
+        from modules.file_encryptor import ENC_FILE_SUFFIX, SALT_FILE_SUFFIX, FileEncryptor
+        import modules.file_encryptor as fe_mod
+
+        with tempfile.TemporaryDirectory() as tmp:
+            plain_file = os.path.join(tmp, "plain.txt")
+            Path(plain_file).write_bytes(b"secret data")
+
+            enc = self._make_encryptor()
+
+            mock_dialog = MagicMock()
+            mock_dialog.exec.return_value = MagicMock()  # will compare to QDialog.DialogCode.Accepted
+            mock_dialog.get_password.return_value = "newpassword"
+
+            with patch.object(fe_mod, "PasswordDialog", return_value=mock_dialog) as _pd, \
+                 patch.object(fe_mod.QDialog.DialogCode, "Accepted", mock_dialog.exec.return_value):
+                enc._reencrypt_to_current_standard(plain_file)
+
+            salt_file = plain_file + SALT_FILE_SUFFIX
+            enc_file = plain_file + ENC_FILE_SUFFIX
+
+            self.assertTrue(os.path.exists(salt_file), "Salt file must exist after re-encryption")
+            self.assertTrue(os.path.exists(enc_file), "Enc file must exist after re-encryption")
+            self.assertEqual(os.path.getsize(salt_file), 20, "Salt file must be 20 bytes")
+            self.assertFalse(os.path.exists(plain_file), "Plaintext must be removed")
+
+    def test_reencrypt_atomic_cleanup_on_rename_failure(self):
+        """If rename fails after writing temp enc file, original plaintext is preserved."""
+        from modules.file_encryptor import FileEncryptor
+        import modules.file_encryptor as fe_mod
+
+        with tempfile.TemporaryDirectory() as tmp:
+            plain_file = os.path.join(tmp, "plain.txt")
+            Path(plain_file).write_bytes(b"must survive")
+
+            enc = self._make_encryptor()
+
+            mock_dialog = MagicMock()
+            mock_dialog.get_password.return_value = "pw"
+            mock_dialog.exec.return_value = MagicMock()
+
+            replace_call_count = [0]
+            real_replace = os.replace
+
+            def fake_replace(src, dst):
+                replace_call_count[0] += 1
+                if replace_call_count[0] == 1:
+                    raise OSError("simulated rename failure")
+                return real_replace(src, dst)
+
+            with patch.object(fe_mod, "PasswordDialog", return_value=mock_dialog), \
+                 patch.object(fe_mod.QDialog.DialogCode, "Accepted", mock_dialog.exec.return_value), \
+                 patch("os.replace", side_effect=fake_replace), \
+                 patch.object(fe_mod.QMessageBox, "warning"):
+                enc._reencrypt_to_current_standard(plain_file)
+
+            # Original plaintext must still exist
+            self.assertTrue(os.path.exists(plain_file), "Plaintext must be preserved on failure")
+            self.assertEqual(Path(plain_file).read_bytes(), b"must survive")
+            # No leftover .enc.tmp files
+            tmp_files = [f for f in os.listdir(tmp) if f.endswith(".enc.tmp") or f.endswith(".salt.tmp")]
+            self.assertEqual(tmp_files, [], f"Temp files not cleaned up: {tmp_files}")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_file_encryptor.py
+++ b/tests/test_file_encryptor.py
@@ -309,6 +309,10 @@ class TestReencryptToCurrentStandard(unittest.TestCase):
 
     def test_reencrypt_produces_20_byte_salt_and_enc_file(self):
         """_reencrypt_to_current_standard must produce a 20-byte .salt and .enc file."""
+        import struct
+
+        from cryptography.fernet import Fernet
+
         import modules.file_encryptor as fe_mod
         from modules.file_encryptor import ENC_FILE_SUFFIX, SALT_FILE_SUFFIX
 
@@ -338,6 +342,17 @@ class TestReencryptToCurrentStandard(unittest.TestCase):
             self.assertTrue(os.path.exists(enc_file), "Enc file must exist after re-encryption")
             self.assertEqual(os.path.getsize(salt_file), 20, "Salt file must be 20 bytes")
             self.assertFalse(os.path.exists(plain_file), "Plaintext must be removed")
+
+            salt_content = Path(salt_file).read_bytes()
+            iterations = struct.unpack(">I", salt_content[:4])[0]
+            self.assertEqual(iterations, _PBKDF2_ITERATIONS)
+
+            salt = salt_content[4:]
+            key = EncryptionWorker("encrypt", enc_file, "newpassword")._derive_key(
+                "newpassword", salt, iterations=_PBKDF2_ITERATIONS
+            )
+            decrypted = Fernet(key).decrypt(Path(enc_file).read_bytes())
+            self.assertEqual(decrypted, b"secret data")
 
     def test_reencrypt_atomic_cleanup_on_rename_failure(self):
         """If rename fails after writing temp enc file, original plaintext is preserved."""


### PR DESCRIPTION
## Summary

Legacy-encrypted files (those using the pre-upgrade 100,000-iteration PBKDF2 key) already decrypt correctly via silent fallback, but the user receives no indication that their file was protected by a weaker work factor, and no mechanism exists to upgrade it. This PR closes that gap by surfacing a non-blocking warning after legacy decryption succeeds and offering an atomic in-place re-encryption step that upgrades the file to the current 600,000-iteration standard.

## Changes

**`src/modules/file_encryptor.py`**

- Added `legacy_detected = pyqtSignal(str)` to `EncryptionWorker` — carries the decrypted output file path so the UI knows which file to offer for re-encryption without having to re-derive it (the `.salt` file is already deleted by the time the signal fires).
- Set an `is_legacy` flag inside `EncryptionWorker.run()` when the 16-byte legacy salt branch is taken (line 199), and emit `legacy_detected` after all files decrypt successfully — after `finished_signal` setup but before it fires.
- In `FileEncryptor._process_file()`, initialise `self._legacy_decrypted_path = None` and wire the new `legacy_detected` signal to a slot that stores the path.
- In `FileEncryptor._on_operation_finished()`, after a successful decrypt, check `_legacy_decrypted_path` and show a `QMessageBox.question()` offering re-encryption; if accepted, invoke the atomic re-encryption helper with the stored path.
- Implemented an atomic re-encryption helper: encrypts the plaintext file under fresh 600,000-iteration parameters, writes `.enc` and 20-byte `.salt` to temp files, then renames both into place — the original plaintext is never deleted unless both writes succeed.

**`docs/features.md`**

- Added a "Salt Format and Migration" subsection under File Encryption documenting the 20-byte current format, the 16-byte legacy format, and the in-app upgrade path.

**`tests/test_file_encryptor.py`**

- Added tests covering `legacy_detected` signal emission when a 16-byte salt file is present.
- Added tests covering the atomic re-encryption helper: verifies output produces a 20-byte `.salt` file and that the resulting `.enc` file decrypts correctly under the new iteration count.

## Testing

**Automated**

Run the full test suite:

```
pytest tests/test_file_encryptor.py -v
```

All new tests should be GREEN. Legacy decryption tests introduced earlier (`test_legacy_16_byte_salt_decrypts_correctly`) must still pass.

**Manual verification**

1. Create a plaintext file and encrypt it manually using PBKDF2-HMAC-SHA256 with 100,000 iterations + Fernet, saving only the 16-byte random salt as the `.salt` file alongside the `.enc` file.
2. Open the application and decrypt the file using the correct password.
3. Verify that decryption succeeds and a dialog appears informing you that the file was encrypted with a legacy key, offering a Re-encrypt option.
4. Accept the prompt, enter the password, and confirm that a new 20-byte `.salt` file is written and the `.enc` file is replaced.
5. Decrypt the newly re-encrypted file and confirm the plaintext is intact.
6. Repeat step 1 but decline the re-encrypt prompt — confirm the decrypted file is present and no re-encryption occurs.

Closes #70