### PR TITLE
fix: resolve #80 - BUG: Clear EncryptionWorker password from memory after opera

### DIFF
--- a/src/modules/file_encryptor.py
+++ b/src/modules/file_encryptor.py
@@ -272,6 +272,7 @@ class EncryptionWorker(QThread):
             logger.error("Encryption worker failed: %s", str(e))
             self.finished_signal.emit(False, f"Operation failed: {str(e)}")
         finally:
+            password = None  # best-effort: drop local reference too
             self.password = None
 
 

--- a/src/modules/file_encryptor.py
+++ b/src/modules/file_encryptor.py
@@ -45,7 +45,7 @@ class EncryptionWorker(QThread):
         super().__init__()
         self.operation = operation  # 'encrypt' or 'decrypt'
         self.file_path = file_path
-        self.password = password  # best-effort only: cleared after run(); CPython may retain internals
+        self.password = password  # best-effort only: cleared after run(); CPython may retain string contents in memory
         self.is_folder = is_folder
 
     def _derive_key(

--- a/src/modules/file_encryptor.py
+++ b/src/modules/file_encryptor.py
@@ -151,6 +151,7 @@ class EncryptionWorker(QThread):
         logger.info("Starting %s operation on: %s", self.operation, self.file_path)
         is_legacy = False
         password = self.password
+        self.password = None  # best-effort: drop instance reference ASAP
         try:
             if password is None:
                 self.finished_signal.emit(False, "Password is required.")

--- a/src/modules/file_encryptor.py
+++ b/src/modules/file_encryptor.py
@@ -153,7 +153,8 @@ class EncryptionWorker(QThread):
         password = self.password
         try:
             if password is None:
-                raise RuntimeError("Password reference missing before operation start.")
+                self.finished_signal.emit(False, "Password is required.")
+                return
             # Generate salt
             salt = os.urandom(16)
             key = self._derive_key(password, salt)

--- a/src/modules/file_encryptor.py
+++ b/src/modules/file_encryptor.py
@@ -45,7 +45,7 @@ class EncryptionWorker(QThread):
         super().__init__()
         self.operation = operation  # 'encrypt' or 'decrypt'
         self.file_path = file_path
-        self.password = password
+        self.password = password  # best-effort only: cleared after run(); CPython may retain internals
         self.is_folder = is_folder
 
     def _derive_key(
@@ -142,13 +142,21 @@ class EncryptionWorker(QThread):
         return files
 
     def run(self):
-        """Run the encryption/decryption operation."""
+        """Run the encryption/decryption operation.
+
+        Best-effort secret handling only: the worker clears its password reference
+        in finally, but CPython cannot guarantee the underlying string bytes are
+        zeroised immediately.
+        """
         logger.info("Starting %s operation on: %s", self.operation, self.file_path)
         is_legacy = False
+        password = self.password
         try:
+            if password is None:
+                raise RuntimeError("Password reference missing before operation start.")
             # Generate salt
             salt = os.urandom(16)
-            key = self._derive_key(self.password, salt)
+            key = self._derive_key(password, salt)
 
             # Get all files to process
             files_to_process = self._get_all_files(self.file_path, self.operation)
@@ -205,7 +213,7 @@ class EncryptionWorker(QThread):
                             False, "Salt file is corrupt or unrecognised format. Cannot decrypt."
                         )
                         return
-                    key = self._derive_key(self.password, salt, iterations=stored_iterations)
+                    key = self._derive_key(password, salt, iterations=stored_iterations)
                 else:
                     self.finished_signal.emit(
                         False, "Salt file not found. Cannot decrypt without the original salt."
@@ -262,6 +270,8 @@ class EncryptionWorker(QThread):
         except Exception as e:
             logger.error("Encryption worker failed: %s", str(e))
             self.finished_signal.emit(False, f"Operation failed: {str(e)}")
+        finally:
+            self.password = None
 
 
 class PasswordDialog(QDialog):

--- a/tests/test_file_encryptor.py
+++ b/tests/test_file_encryptor.py
@@ -104,7 +104,7 @@ class TestEncryptDecryptRoundTrip(unittest.TestCase):
         worker.progress_updated = MagicMock()
         worker.status_updated = MagicMock()
         worker.run()
-        return results
+        return worker, results
 
     def test_new_salt_file_is_20_bytes(self):
         """After encryption the .salt file must be 20 bytes (4 + 16)."""
@@ -112,7 +112,7 @@ class TestEncryptDecryptRoundTrip(unittest.TestCase):
             plain_file = os.path.join(tmp, "data.txt")
             Path(plain_file).write_text("hello world")
 
-            result = self._run_worker("encrypt", plain_file, "pass123")
+            _worker, result = self._run_worker("encrypt", plain_file, "pass123")
             self.assertTrue(result.get("success"), result.get("message"))
 
             salt_file = plain_file + ".salt"
@@ -130,14 +130,25 @@ class TestEncryptDecryptRoundTrip(unittest.TestCase):
             plain_file = os.path.join(tmp, "secret.txt")
             Path(plain_file).write_bytes(original_content)
 
-            enc_result = self._run_worker("encrypt", plain_file, "mypassword")
+            _enc_worker, enc_result = self._run_worker("encrypt", plain_file, "mypassword")
             self.assertTrue(enc_result.get("success"), enc_result.get("message"))
 
             enc_file = plain_file + ".enc"
-            dec_result = self._run_worker("decrypt", enc_file, "mypassword")
+            _dec_worker, dec_result = self._run_worker("decrypt", enc_file, "mypassword")
             self.assertTrue(dec_result.get("success"), dec_result.get("message"))
 
             self.assertEqual(Path(plain_file).read_bytes(), original_content)
+
+    def test_password_reference_cleared_after_run(self):
+        """Worker must clear the plaintext password reference after finishing."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plain_file = os.path.join(tmp, "secret.txt")
+            Path(plain_file).write_text("top secret")
+
+            worker, result = self._run_worker("encrypt", plain_file, "mypassword")
+
+        self.assertTrue(result.get("success"), result.get("message"))
+        self.assertIsNone(worker.password)
 
 
 class TestLegacySaltFallback(unittest.TestCase):


### PR DESCRIPTION
## Summary

Resolves #80 — clears the `EncryptionWorker` password reference after encrypt/decrypt work finishes so plaintext credentials are not retained on the worker instance longer than necessary.

## Changes

- **`src/modules/file_encryptor.py`**: documented the best-effort nature of password cleanup, copied `self.password` into a local variable for the active operation, and cleared `self.password` in a `finally` block so the instance no longer retains the plaintext password after `run()` completes.
- **`tests/test_file_encryptor.py`**: updated the worker test helper to return the worker instance and expanded round-trip coverage so tests can assert the password reference is cleared after execution while preserving existing encryption/decryption behavior checks.

## Testing

- Run `pytest tests/test_file_encryptor.py` and confirm the round-trip encryption/decryption tests pass and the worker instance has `password is None` after `run()` returns.

## Closes #80